### PR TITLE
125 add windows tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # we assume it also works for inbetween versions
         python-version: ["3.8", "3.12", "3.13"]
-        os: [ubuntu-latest] #, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest] #, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # we assume it also works for inbetween versions
         python-version: ["3.8", "3.12", "3.13"]
-        os: [ubuntu-latest, windows-latest] #, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ examples = [
 	"matplotlib",
 ]
 netcdf = [
-	"xarray[io]",
+	"xarray",
+	"h5netcdf",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Steps:
- failing for windows with Python 3.8 (netcdf4 1.7.2 is being installed, but [py38-windows-wheels are not available](https://pypi.org/project/netCDF4/#files))
- solved by moving from `xarray[io]` (included netcdf4) to `xarray` (plain) and `h5netcdf`